### PR TITLE
Fix event emitter memory leak warning

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ var midiout = createMidiOutInterface("Ps3 Midi Controller");
 var dualshock = new DualShock();
 var isLocked = false;
 
-
+dualshock.setMaxListeners(0);
 dualshock.start();
 
 console.log(fs.readFileSync(__dirname+'/splash.txt','utf-8'));


### PR DESCRIPTION
Fix event emitter warning according to 
https://nodejs.org/docs/latest/api/events.html#events_emitter_setmaxlisteners_n
